### PR TITLE
Fix for Browserify. Close #25 and #26.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var Infinite = require('react-infinite');
 ```
 
 ### In Browserify
-If you want to use the source Browserify, the relevant file to include is `src/react_infinite.jsx`. You **must** create the bundle with a compiler that supports both ES6 and JSX compilation. `reactify` with the `harmony` option turned on will suffice - examine the `preprocessor.js` tools to see an example of the compilation for tests.
+If you want to use the source with Browserify, you may require it in a similar manner to the NPM instructions above. You **must** have Reactify to compile the JSX and ES6, however.
 
 Otherwise, you can follow the instructions for NPM.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A browser-ready efficient scrolling container based on UITableView",
   "main": "dist/react-infinite.js",
   "repository": {
@@ -18,6 +18,14 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/seatgeek/react-infinite/issues"
+  },
+  "browser": "src/react-infinite.jsx",
+  "browserify": {
+    "transform": [
+      ["reactify", {
+        "es6": true
+      }]
+    ]
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
This pull request directs Browserify to use `src/react-infinite.jsx` when compiling. Reactify is required if you wish to use the source with Browserify.