### PR TITLE
remove not using code in Gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,6 @@ var gulp = require('gulp'),
   minifyjs = require('gulp-uglify'),
   browserify = require('browserify'),
   sourcemaps = require('gulp-sourcemaps'),
-  browserifyShim = require('browserify-shim'),
   sourcestream = require('vinyl-source-stream');
 
 var args = require('yargs').alias('P', 'production')
@@ -41,4 +40,3 @@ gulp.task('build', function() {
 });
 
 gulp.task('default', ['build']);
-


### PR DESCRIPTION
browserify-shim isn't installed in npm

I found out this problem when I build example code.