### PR TITLE
Handle boundary condition in calculating display index end

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,6 @@ var gulp = require('gulp'),
   minifyjs = require('gulp-uglify'),
   browserify = require('browserify'),
   sourcemaps = require('gulp-sourcemaps'),
-  browserifyShim = require('browserify-shim'),
   sourcestream = require('vinyl-source-stream');
 
 var args = require('yargs').alias('P', 'production')
@@ -41,4 +40,3 @@ gulp.task('build', function() {
 });
 
 gulp.task('default', ['build']);
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 React Infinite
 ===
-[![Build Status](https://travis-ci.org/seatgeek/react-infinite.svg?branch=master)](https://travis-ci.org/seatgeek/react-infinite.svg)
+[![Build Status](https://travis-ci.org/seatgeek/react-infinite.svg?branch=master)](https://travis-ci.org/seatgeek/react-infinite)
 [![Coverage Status](https://coveralls.io/repos/seatgeek/react-infinite/badge.svg)](https://coveralls.io/r/seatgeek/react-infinite)
 
 **A browser-ready efficient scrolling container based on UITableView. Now supports elements of variable heights!**

--- a/__tests__/array_infinite_computer_test.js
+++ b/__tests__/array_infinite_computer_test.js
@@ -46,17 +46,37 @@ describe("Array Infinite Computer", () => {
 
     xit("computes indexes correctly with zero-height elements", () => {
     });
+
+
+    it("computes a zero display index correctly", () => {
+      var aic = new ArrayInfiniteComputer([20], 1);
+      expect(aic.getDisplayIndexStart(10)).toEqual(0);
+    });
   });
 
   describe("getDisplayIndexEnd()", () => {
     it("computes the correct display index when precisely at element border", () => {
       var aic = new ArrayInfiniteComputer([130, 120, 110, 100, 90, 80, 70], 7);
-      expect(aic.getDisplayIndexEnd(550)).toEqual(5);
+      expect(aic.getDisplayIndexEnd(550)).toEqual(4);
     });
 
     it("computes the correct display index when not precisely at element border", () => {
       var aic = new ArrayInfiniteComputer([130, 120, 110, 100, 90, 80, 70], 7);
-      expect(aic.getDisplayIndexEnd(444)).toEqual(4);
+      expect(aic.getDisplayIndexEnd(444)).toEqual(3);
+    });
+
+    it("computes the correct end index when all items fit within the container", () => {
+      var aic = new ArrayInfiniteComputer([28], 1);
+      expect(aic.getDisplayIndexEnd(627)).toEqual(0);
+
+      aic = new ArrayInfiniteComputer([28, 28, 28, 10], 4);
+      expect(aic.getDisplayIndexEnd(627)).toEqual(3);
+    });
+
+    it("returns -1 when there are no items", () => {
+      var aic = new ArrayInfiniteComputer([], 0);
+      expect(aic.getDisplayIndexEnd(800)).toEqual(-1);     
+      expect(aic.getDisplayIndexEnd(0)).toEqual(-1);     
     });
 
     xit("computes indexes correctly with zero-height elements", () => {
@@ -71,20 +91,28 @@ describe("Array Infinite Computer", () => {
 
     it("correctly computes a regular top spacer height", () => {
       var aic = new ArrayInfiniteComputer([40, 80, 160, 320], 4);
+      expect(aic.getTopSpacerHeight(1)).toEqual(40);
       expect(aic.getTopSpacerHeight(2)).toEqual(120);
+      expect(aic.getTopSpacerHeight(3)).toEqual(280);
     });
   });
 
   describe("getBottomSpacerHeight()", () => {
-    it("correctly computes a zero bottom spacer height", () => {
-      // Note the displayIndexEnd is not inclusive
+    it("correctly computes a bottom spacer height when the last item is rendered", () => {
       var aic = new ArrayInfiniteComputer([20, 40, 80, 160], 4);
-      expect(aic.getBottomSpacerHeight(4)).toEqual(0);
+      expect(aic.getBottomSpacerHeight(3)).toEqual(0);
     });
 
     it("correctly computes a regular bottom spacer height", () => {
       var aic = new ArrayInfiniteComputer([20, 40, 80, 160], 4);
-      expect(aic.getBottomSpacerHeight(3)).toEqual(160);
+      expect(aic.getBottomSpacerHeight(0)).toEqual(280);
+      expect(aic.getBottomSpacerHeight(1)).toEqual(240);
+      expect(aic.getBottomSpacerHeight(2)).toEqual(160);
+    });
+
+    it("correctly computes bottom spacer height when there are no items", () => {
+      var aic = new ArrayInfiniteComputer([], 0);
+      expect(aic.getBottomSpacerHeight(-1)).toEqual(0);
     });
   });
 });

--- a/__tests__/binary_search_test.js
+++ b/__tests__/binary_search_test.js
@@ -106,6 +106,6 @@ describe("Binary Index Search", function() {
       expect(binaryIndexSearch(oddArray, 11, bs.opts.CLOSEST_HIGHER)).toEqual(0);
       expect(binaryIndexSearch(oddArray, 203, bs.opts.CLOSEST_HIGHER)).toEqual(1);
       expect(binaryIndexSearch(oddArray, 482, bs.opts.CLOSEST_HIGHER)).toEqual(2);
-    })
+    });
   });
 })

--- a/__tests__/constant_infinite_computer_test.js
+++ b/__tests__/constant_infinite_computer_test.js
@@ -38,12 +38,12 @@ describe("Constant Infinite Computer", () => {
     });
 
     it("computes the correct display index when precisely at element border", () => {
-      expect(cic.getDisplayIndexEnd(94)).toEqual(2);
-      expect(cic.getDisplayIndexEnd(611)).toEqual(13);
+      expect(cic.getDisplayIndexEnd(94)).toEqual(1);
+      expect(cic.getDisplayIndexEnd(611)).toEqual(12);
     });
 
     it("computes the correct display index when below element border", () => {
-      expect(cic.getDisplayIndexEnd(417)).toEqual(9);
+      expect(cic.getDisplayIndexEnd(417)).toEqual(8);
     });
 
     it("computes a zero display index correctly", () => {

--- a/__tests__/infinite_test.js
+++ b/__tests__/infinite_test.js
@@ -113,17 +113,19 @@ describe('The Children of the React Infinite Component', function() {
     // preloadAdditionalHeight defaults to the containerHeight, 800 pixels
     //
     // Their sum is 1200 pixels, or 6 200-pixel elements.
-    for (var i = 0; i < 6; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).not.toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-0')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-1')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-2')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-3')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-4')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-5')}).not.toThrow();
 
-    for (var i = 6; i < 10; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-6')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-7')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-8')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-9')}).toThrow();
+    
+
   });
 
   it ("renders more children when preloadAdditionalHeight is increased beyond its default", function() {
@@ -148,17 +150,19 @@ describe('The Children of the React Infinite Component', function() {
     // preloadAdditionalHeight is declared as 1000 pixels
     //
     // Their sum is 1400 pixels, or 7 200-pixel elements.
-    for (var i = 0; i < 7; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).not.toThrow();
-    }
 
-    for (var i = 7; i < 10; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-0')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-1')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-2')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-3')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-4')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-5')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-6')}).not.toThrow();
+
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-7')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-8')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-9')}).toThrow();
+
   });
 
   it ("renders more children when preloadBatchSize is increased beyond its default", function() {
@@ -183,17 +187,18 @@ describe('The Children of the React Infinite Component', function() {
     // preloadAdditionalHeight defaults to containerHeight, 800 pixels
     //
     // Their sum is 1600 pixels, or 8 200-pixel elements.
-    for (var i = 0; i < 8; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).not.toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-0')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-1')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-2')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-3')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-4')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-5')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-6')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-7')}).not.toThrow();
 
-    for (var i = 8; i < 10; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-8')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-9')}).toThrow();
+
   });
 })
 
@@ -347,25 +352,27 @@ describe('The Behavior of the Variable Height React Infinite Component', functio
     expect(rootNode.refs.bottomSpacer.props.style.height).toEqual("100px");
 
     // Above the batch and its preloadAdditionalHeight
-    for (var i = 0; i < 2; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-0')}).toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-1')}).toThrow();
 
     // Within the batch and its preloadAdditionalHeight, top and bottom
-    for (var i = 2; i < 16; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).not.toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-2')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-3')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-4')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-5')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-6')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-7')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-8')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-9')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-10')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-11')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-12')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-13')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-14')}).not.toThrow();
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-15')}).not.toThrow();
 
     // Below the batch and its preloadAdditionalHeight
-    for (var i = 16; i < 17; i++) {
-      expect(function() {
-        TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-' + i)
-      }).toThrow();
-    }
+    expect(function(){TestUtils.findRenderedDOMComponentWithClass(rootNode, 'test-div-16')}).toThrow();
   });
 
   it("functions correctly at the end of its range", function() {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   },
   "dependencies": {
     "lodash.isarray": "^3.0.0",
-    "lodash.isfinite": "^3.0.0",
+    "lodash.isfinite": "^3.0.0"
+  },
+  "peerDependencies":{
     "react": ">= 0.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A browser-ready efficient scrolling container based on UITableView",
   "main": "dist/react-infinite.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
   "browser": "src/react-infinite.jsx",
   "browserify": {
     "transform": [
-      ["reactify", {
-        "es6": true
-      }]
+      [
+        "reactify",
+        {
+          "es6": true
+        }
+      ]
     ]
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "watch": "watch \"npm test\" ./__tests__ ./src"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/preprocessor.js",
@@ -47,6 +51,8 @@
   },
   "homepage": "https://github.com/seatgeek/react-infinite",
   "devDependencies": {
+    "browserify": "^9.0.3",
+    "coveralls": "^2.11.2",
     "gulp": "^3.8.8",
     "gulp-concat": "^2.4.3",
     "gulp-if": "^1.2.5",
@@ -55,14 +61,12 @@
     "gulp-sourcemaps": "^1.2.4",
     "gulp-uglify": "^1.0.1",
     "jest-cli": "0.4.0",
-    "yargs": "^1.3.2",
     "react-tools": "*",
-    "browserify": "^9.0.3",
-    "react": ">= 0.12.2",
     "reactify": "^1.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "coveralls": "^2.11.2"
+    "watch": "^0.16.0",
+    "yargs": "^1.3.2"
   },
   "dependencies": {
     "lodash.isarray": "^3.0.0",

--- a/src/computers/array_infinite_computer.js
+++ b/src/computers/array_infinite_computer.js
@@ -24,7 +24,8 @@ class ArrayInfiniteComputer extends InfiniteComputer {
   }
 
   getDisplayIndexEnd(windowBottom) {
-    return bs.binaryIndexSearch(this.prefixHeightData, windowBottom, bs.opts.CLOSEST_HIGHER) + 1;
+    var foundIndex = bs.binaryIndexSearch(this.prefixHeightData, windowBottom, bs.opts.CLOSEST_HIGHER);
+    return typeof foundIndex === 'undefined' ? this.prefixHeightData.length - 1 : foundIndex; 
   }
 
   getTopSpacerHeight(displayIndexStart) {
@@ -33,14 +34,8 @@ class ArrayInfiniteComputer extends InfiniteComputer {
   }
 
   getBottomSpacerHeight(displayIndexEnd) {
-    var previous = displayIndexEnd - 1;
-    if (displayIndexEnd === 0) {
-      return this.getTotalScrollableHeight();
-    } else if (displayIndexEnd >= this.prefixHeightData.length) {
-      return 0;
-    } else {
-      return this.getTotalScrollableHeight() - this.prefixHeightData[previous];
-    }
+    if (displayIndexEnd === -1) return 0;
+    return this.getTotalScrollableHeight() - this.prefixHeightData[displayIndexEnd];
   }
 }
 

--- a/src/computers/constant_infinite_computer.js
+++ b/src/computers/constant_infinite_computer.js
@@ -10,7 +10,11 @@ class ConstantInfiniteComputer extends InfiniteComputer {
   }
 
   getDisplayIndexEnd(windowBottom) {
-    return Math.ceil(windowBottom / this.heightData);
+    var nonZeroIndex = Math.ceil(windowBottom / this.heightData);
+    if (nonZeroIndex > 0) {
+      return nonZeroIndex - 1;
+    }
+    return nonZeroIndex;
   }
 
   getTopSpacerHeight(displayIndexStart) {
@@ -18,7 +22,8 @@ class ConstantInfiniteComputer extends InfiniteComputer {
   }
 
   getBottomSpacerHeight(displayIndexEnd) {
-    return Math.max(0, (this.numberOfChildren - displayIndexEnd) * this.heightData);
+    var nonZeroIndex = displayIndexEnd + 1;
+    return Math.max(0, (this.numberOfChildren - nonZeroIndex) * this.heightData);
   }
 }
 

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -63,16 +63,12 @@ var Infinite = React.createClass({
       infiniteComputer: computer,
 
       numberOfChildren: this.props.children.length,
-      scrollableHeight: undefined,
       displayIndexStart: 0,
       displayIndexEnd: computer.getDisplayIndexEnd(
                         preloadBatchSize + preloadAdditionalHeight
                       ),
 
       isInfiniteLoading: false,
-
-      currentScrollTop: undefined,
-      previousScrollTop: undefined,
 
       preloadBatchSize: preloadBatchSize,
       preloadAdditionalHeight: preloadAdditionalHeight,
@@ -145,20 +141,8 @@ var Infinite = React.createClass({
     }
   },
 
-  componentDidMount() {
-    this.setState({
-      scrollableHeight: this.refs.scrollable.getDOMNode().clientHeight,
-      currentScrollTop: this.getScrollTop(),
-      previousScrollTop: this.getScrollTop()
-    });
-  },
-
   getScrollTop() {
     return this.refs.scrollable.getDOMNode().scrollTop;
-  },
-
-  isScrollingDown() {
-    return this.state.previousScrollTop < this.state.currentScrollTop;
   },
 
   // Given the scrollTop of the container, computes the state the
@@ -175,9 +159,7 @@ var Infinite = React.createClass({
                         blockEnd + this.state.preloadAdditionalHeight)
     this.setState({
       displayIndexStart: this.state.infiniteComputer.getDisplayIndexStart(windowTop),
-      displayIndexEnd: this.state.infiniteComputer.getDisplayIndexEnd(windowBottom),
-      currentScrollTop: scrollTop,
-      previousScrollTop: this.state.currentScrollTop
+      displayIndexEnd: this.state.infiniteComputer.getDisplayIndexEnd(windowBottom)
     });
   },
 

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -240,7 +240,7 @@ var Infinite = React.createClass({
   render() {
     var that = this;
     var displayables = this.props.children.slice(this.state.displayIndexStart,
-                                                 this.state.displayIndexEnd);
+                                                 this.state.displayIndexEnd + 1);
 
     var infiniteScrollStyles = {};
     if (this.state.isScrolling) {


### PR DESCRIPTION
Changed array_infinite_computer.getDisplayIndexEnd to be zero index based instead of handling the conversion for the sake of the array.slice.

Updated bottom spacer height calculation to account for new zero index end.

Guarded against leaking undefined from the binary index search to the component. There was an edge case where if there was an array with one item thats height was less than the available container height the index search would return undefined. This is to be expected because the getDisplayIndexEnd was only looking for the CLOSEST_HIGHER item which did not exist. But leaking this result to the component would cause the bottom spacer to have a height of "NaNpx". So the getDisplayIndexEnd function now protects in this particular case and just returns the last index of the array's items.