### PR TITLE
preloadBatchSize set to zero results in infinite loop.

### DIFF
--- a/__tests__/infinite_test.js
+++ b/__tests__/infinite_test.js
@@ -72,6 +72,16 @@ describe('Rendering the React Infinite Component Wrapper', function() {
 
     expect(infinite.props.className).toEqual("correct-class-name");
   });
+
+  it('allows preloadBatchSize to be zero', function() {
+    var renderedInfinite = TestUtils.renderIntoDocument(<Infinite elementHeight={[28,28]} containerHeight={100}
+                             preloadBatchSize={0}>
+                        <li>Test1</li>
+                        <li>Test2</li>
+                    </Infinite>);
+
+    TestUtils.Simulate.scroll(renderedInfinite.getDOMNode());
+  });
 })
 
 describe('The Children of the React Infinite Component', function() {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "browser": "build/react-infinite.js",
   "scripts": {
     "test": "jest",
-    "watch": "watch \"npm test\" ./__tests__ ./src",
+    "watch-test": "watch \"npm test\" ./__tests__ ./src",
+    "watch-build": "watch \"gulp build -E\" ./examples ./src",
     "build": "gulp build && gulp build -E"
   },
   "jest": {

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -116,13 +116,13 @@ var Infinite = React.createClass({
   },
 
   getPreloadBatchSizeFromProps(props) {
-    return props.preloadBatchSize ?
+    return typeof props.preloadBatchSize === 'number' ?
       props.preloadBatchSize :
       props.containerHeight / 2;
   },
 
   getPreloadAdditionalHeightFromProps(props) {
-    return props.preloadAdditionalHeight ?
+    return typeof props.preloadAdditionalHeight === 'number' ?
       props.preloadAdditionalHeight :
       props.containerHeight;
   },
@@ -151,12 +151,12 @@ var Infinite = React.createClass({
   // The window is the block with any preloadAdditionalHeight
   // added to it.
   setStateFromScrollTop(scrollTop) {
-    var blockNumber = Math.floor(scrollTop / this.state.preloadBatchSize),
+    var blockNumber = this.state.preloadBatchSize === 0 ? 0 : Math.floor(scrollTop / this.state.preloadBatchSize),
         blockStart = this.state.preloadBatchSize * blockNumber,
         blockEnd = blockStart + this.state.preloadBatchSize,
         windowTop = Math.max(0, blockStart - this.state.preloadAdditionalHeight),
         windowBottom = Math.min(this.state.infiniteComputer.getTotalScrollableHeight(),
-                        blockEnd + this.state.preloadAdditionalHeight)
+                        blockEnd + this.state.preloadAdditionalHeight);
     this.setState({
       displayIndexStart: this.state.infiniteComputer.getDisplayIndexStart(windowTop),
       displayIndexEnd: this.state.infiniteComputer.getDisplayIndexEnd(windowBottom)


### PR DESCRIPTION
… a scroll event the windowTop and windowBottom would be NaN. The array infinite computer would receive NaN and end up in an infinite loop crashing the browser.