### PR TITLE
v0.5: Window as Container

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+.*/fbjs/.*
 
 [include]
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Defaults to `this.props.containerHeight`. The total height of the area in which 
 #### **Function** `handleScroll(DOMNode node)`
 Defaults to `function(){}`. A function that is called when the container is scrolled, i.e. when the `onScroll` event of the infinite scrolling container is fired. The only argument passed to it is the native DOM [Node](https://developer.mozilla.org/en-US/docs/Web/API/Node) of the scrolling container.
 
+#### Bool `useWindowAsScrollContainer`
+Defaults to `false`. This option allows the window to be used as the scroll container, instead of an arbitrary `div`, when it is set to `true`. This means that scroll position is detected by `window.scrollY` instead of the `scrollTop` of the `div` that React Infinite creates. Using this option is a way of achieving smoother scrolling on mobile before the problem is solved for container `div`s.
+
 #### **Number** `infiniteLoadBeginBottomOffset`
 When the user reaches this number of pixels from the bottom, the infinite load sequence will be triggered by showing the infinite load spinner delegate and calling the function `onInfiniteLoad`. To disable infinite loading, do not provide this property.
 

--- a/examples/borderless-window.html
+++ b/examples/borderless-window.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <style>
+    body {
+        margin: 0;
+    }
+
+    .infinite-list-item {
+        text-align: center;
+        width: 100vw;
+        margin: auto;
+        vertical-align: bottom;
+    }
+
+    .infinite-list-item {
+        border-bottom: 1px solid #ddd;
+    }
+
+    .infinite-list-item:last-child span {
+        border-bottom: 0;
+    }
+
+    </style>
+  </head>
+  <body>
+    <div id="infinite-window-example" class="infinite-example"></div>
+    <script src="../node_modules/react/dist/react.js"></script>
+    <script src="../dist/react-infinite.js"></script>
+    <!-- Run gulp build -E to create this file. -->
+    <script src="./borderless-window.js"></script>
+  </body>
+</html>

--- a/examples/borderless-window.jsx
+++ b/examples/borderless-window.jsx
@@ -1,0 +1,76 @@
+var ListItem = React.createClass({
+    getDefaultProps: function() {
+        return {
+            height: 50,
+            lineHeight: "50px"
+        }
+    },
+    render: function() {
+        return <div className="infinite-list-item" style={
+            {
+                height: this.props.height,
+                lineHeight: this.props.lineHeight,
+                overflow: 'scroll'
+            }
+        }>
+            <div style={{height: 50}}>
+            List Item {this.props.index}
+            </div>
+        </div>;
+    }
+});
+
+var InfiniteList = React.createClass({
+    getInitialState: function() {
+        return {
+            elements: this.buildElements(0, 50),
+            isInfiniteLoading: false
+        }
+    },
+
+    buildElements: function(start, end) {
+        var elements = [];
+        for (var i = start; i < end; i++) {
+            elements.push(<ListItem key={i} index={i}/>)
+        }
+        return elements;
+    },
+
+    handleInfiniteLoad: function() {
+        var that = this;
+        this.setState({
+            isInfiniteLoading: true
+        });
+        setTimeout(function() {
+            var elemLength = that.state.elements.length,
+                newElements = that.buildElements(elemLength, elemLength + 100);
+            that.setState({
+                isInfiniteLoading: false,
+                elements: that.state.elements.concat(newElements)
+            });
+        }, 2500);
+    },
+
+    elementInfiniteLoad: function() {
+        return <div className="infinite-list-item">
+            Loading...
+        </div>;
+    },
+
+    render: function() {
+        return <Infinite elementHeight={50}
+                         containerHeight={window.innerHeight}
+                         infiniteLoadBeginBottomOffset={200}
+                         onInfiniteLoad={this.handleInfiniteLoad}
+                         loadingSpinnerDelegate={this.elementInfiniteLoad()}
+                         isInfiniteLoading={this.state.isInfiniteLoading}
+                         timeScrollStateLastsForAfterUserScrolls={1000}
+                         useWindowAsScrollContainer={true}
+                         >
+                    {this.state.elements}
+                </Infinite>;
+    }
+});
+
+React.render(<InfiniteList/>,
+        document.getElementById('infinite-window-example'));

--- a/examples/window.jsx
+++ b/examples/window.jsx
@@ -13,7 +13,7 @@ var ListItem = React.createClass({
                 overflow: 'scroll'
             }
         }>
-            <div style={{height: 400}}>
+            <div style={{height: 50}}>
             List Item {this.props.index}
             </div>
         </div>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A browser-ready efficient scrolling container based on UITableView",
   "main": "build/react-infinite.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint": "./node_modules/.bin/eslint ./src --ext .jsx --ext .js",
     "typecheck": "./node_modules/.bin/flow check",
     "verify": "npm run lint && npm run typecheck && npm test",
-
     "watch-test": "watch \"npm test\" ./__tests__ ./src",
     "watch-build": "watch \"gulp build -E\" ./examples ./src",
     "build": "gulp build && gulp build -E"
@@ -73,11 +72,12 @@
     "yargs": "^1.3.2"
   },
   "dependencies": {
-    "react": ">= 0.12.2",
     "lodash.isarray": "^3.0.0",
-    "lodash.isfinite": "^3.0.0"
+    "lodash.isfinite": "^3.0.0",
+    "object-assign": "^4.0.1",
+    "react": ">= 0.13.0"
   },
   "peerDependencies": {
-    "react": ">= 0.12.2"
+    "react": ">= 0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-standard": "^4.1.0",
     "eslint-plugin-react": "^3.2.3",
     "eslint-plugin-standard": "^1.2.0",
-    "flow-bin": "^0.14.0",
+    "flow-bin": "^0.17.0",
     "gulp": "^3.8.8",
     "gulp-concat": "^2.4.3",
     "gulp-if": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-jest": "^5.3.0",
     "browserify": "^9.0.3",
     "coveralls": "^2.11.2",
-    "eslint": "^1.1.0",
+    "eslint": "~1.6.0",
     "eslint-config-semistandard": "^5.0.0",
     "eslint-config-standard": "^4.1.0",
     "eslint-plugin-react": "^3.2.3",

--- a/src/computers/array_infinite_computer.js
+++ b/src/computers/array_infinite_computer.js
@@ -5,7 +5,7 @@ var InfiniteComputer = require('./infinite_computer.js'),
 
 class ArrayInfiniteComputer extends InfiniteComputer {
 
-  constructor(heightData/* : Array<number> */, numberOfChildren/* : number */): void {
+  constructor(heightData/* : Array<number> */, numberOfChildren/* : number */)/* : void */ {
     super(heightData, numberOfChildren);
     this.prefixHeightData = this.heightData.reduce((acc, next) => {
       if (acc.length === 0) {

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -102,12 +102,12 @@ var Infinite = React.createClass({
 
   generateComputedProps(props) {
     var computedProps = _assign({}, props);
-    computedProps.containerHeight = props.useWindowAsScrollContainer ?
-      window.innerHeight : props.containerHeight;
-    computedProps.preloadBatchSize = typeof props.preloadBatchSize === 'number' ?
-      props.preloadBatchSize : computedProps.containerHeight / 2;
-    computedProps.preloadAdditionalHeight = typeof props.preloadAdditionalHeight === 'number' ?
-      props.preloadAdditionalHeight : computedProps.containerHeight;
+    computedProps.containerHeight = props.useWindowAsScrollContainer
+      ? window.innerHeight : props.containerHeight;
+    computedProps.preloadBatchSize = typeof props.preloadBatchSize === 'number'
+      ? props.preloadBatchSize : computedProps.containerHeight / 2;
+    computedProps.preloadAdditionalHeight = typeof props.preloadAdditionalHeight === 'number'
+      ? props.preloadAdditionalHeight : computedProps.containerHeight;
     return computedProps;
   },
 

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -3,6 +3,7 @@ var React = global.React || require('react'),
     _isFinite = require('lodash.isfinite'),
     ConstantInfiniteComputer = require('./computers/constant_infinite_computer.js'),
     ArrayInfiniteComputer = require('./computers/array_infinite_computer.js');
+var _assign = require('object-assign');
 
 var Infinite = React.createClass({
 
@@ -37,6 +38,7 @@ var Infinite = React.createClass({
 
     isInfiniteLoading: React.PropTypes.bool,
     timeScrollStateLastsForAfterUserScrolls: React.PropTypes.number,
+    useWindowAsScrollContainer: React.PropTypes.bool,
 
     className: React.PropTypes.string
   },
@@ -47,22 +49,27 @@ var Infinite = React.createClass({
       loadingSpinnerDelegate: <div/>,
       onInfiniteLoad: () => {},
       isInfiniteLoading: false,
-      timeScrollStateLastsForAfterUserScrolls: 150
+      timeScrollStateLastsForAfterUserScrolls: 150,
+      useWindowAsScrollContainer: false,
+      className: ''
     };
   },
 
   // automatic adjust to scroll direction
   // give spinner a ReactCSSTransitionGroup
   getInitialState() {
-    var computer = this.createInfiniteComputer(this.props.elementHeight, this.props.children);
+    this.computedProps = this.generateComputedProps(this.props);
+    this.utils = this.generateComputedUtilityFunctions(this.props);
 
-    var preloadBatchSize = this.getPreloadBatchSizeFromProps(this.props);
-    var preloadAdditionalHeight = this.getPreloadAdditionalHeightFromProps(this.props);
+    var computer = this.createInfiniteComputer(this.computedProps.elementHeight, this.computedProps.children);
+
+    var preloadBatchSize = this.computedProps.preloadBatchSize;
+    var preloadAdditionalHeight = this.computedProps.preloadAdditionalHeight;
 
     return {
       infiniteComputer: computer,
 
-      numberOfChildren: React.Children.count(this.props.children),
+      numberOfChildren: React.Children.count(this.computedProps.children),
       displayIndexStart: 0,
       displayIndexEnd: computer.getDisplayIndexEnd(
                         preloadBatchSize + preloadAdditionalHeight
@@ -93,56 +100,83 @@ var Infinite = React.createClass({
     return computer;
   },
 
+  generateComputedProps(props) {
+    var computedProps = _assign({}, props);
+    computedProps.containerHeight = props.useWindowAsScrollContainer ?
+      window.innerHeight : props.containerHeight;
+    computedProps.preloadBatchSize = props.preloadBatchSize === 'number' ?
+      props.preloadBatchSize : computedProps.containerHeight / 2;
+    computedProps.preloadAdditionalHeight = props.preloadAdditionalHeight === 'number' ?
+      props.preloadAdditionalHeight : computedProps.containerHeight;
+    return computedProps;
+  },
+
+  generateComputedUtilityFunctions(props) {
+    var utilities = {};
+    if (props.useWindowAsScrollContainer) {
+      utilities.subscribeToScrollListener = () => {
+        window.onscroll = this.infiniteHandleScroll;
+      };
+      utilities.nodeScrollListener = () => {};
+      utilities.getScrollTop = () => window.scrollY;
+      utilities.scrollShouldBeIgnored = () => false;
+      utilities.buildScrollableStyle = () => ({});
+    } else {
+      utilities.subscribeToScrollListener = () => {};
+      utilities.nodeScrollListener = this.infiniteHandleScroll;
+      utilities.getScrollTop = () => React.findDOMNode(this.refs.scrollable).scrollTop;
+      utilities.scrollShouldBeIgnored = event => event.target !== React.findDOMNode(this.refs.scrollable);
+      utilities.buildScrollableStyle = () => {
+        return {
+          height: this.computedProps.containerHeight,
+          overflowX: 'hidden',
+          overflowY: 'scroll'
+        };
+      };
+    }
+    return utilities;
+  },
+
   componentWillReceiveProps(nextProps) {
-    var that = this,
-        newStateObject = {};
+    this.computedProps = this.generateComputedProps(nextProps);
+    this.utils = this.generateComputedUtilityFunctions(nextProps);
+
+    var newStateObject = {};
 
     // TODO: more efficient elementHeight change detection
     newStateObject.infiniteComputer = this.createInfiniteComputer(
-                                        nextProps.elementHeight,
-                                        nextProps.children
+                                        this.computedProps.elementHeight,
+                                        this.computedProps.children
                                       );
 
-    if (nextProps.isInfiniteLoading !== undefined) {
-      newStateObject.isInfiniteLoading = nextProps.isInfiniteLoading;
+    if (this.computedProps.isInfiniteLoading !== undefined) {
+      newStateObject.isInfiniteLoading = this.computedProps.isInfiniteLoading;
     }
 
-    newStateObject.preloadBatchSize = this.getPreloadBatchSizeFromProps(nextProps);
-    newStateObject.preloadAdditionalHeight = this.getPreloadAdditionalHeightFromProps(nextProps);
+    newStateObject.preloadBatchSize = this.computedProps.preloadBatchSize;
+    newStateObject.preloadAdditionalHeight = this.computedProps.preloadAdditionalHeight;
 
     this.setState(newStateObject, () => {
-      that.setStateFromScrollTop(that.getScrollTop());
+      this.setStateFromScrollTop(this.utils.getScrollTop());
     });
   },
 
-  getPreloadBatchSizeFromProps(props) {
-    return typeof props.preloadBatchSize === 'number' ?
-      props.preloadBatchSize :
-      props.containerHeight / 2;
-  },
-
-  getPreloadAdditionalHeightFromProps(props) {
-    return typeof props.preloadAdditionalHeight === 'number' ?
-      props.preloadAdditionalHeight :
-      props.containerHeight;
-  },
-
   componentDidUpdate(prevProps) {
-    if (React.Children.count(this.props.children) !== React.Children.count(prevProps.children)) {
-      this.setStateFromScrollTop(this.getScrollTop());
+    if (React.Children.count(this.computedProps.children) !== React.Children.count(prevProps.children)) {
+      this.setStateFromScrollTop(this.utils.getScrollTop());
     }
   },
 
   componentWillMount() {
-    if (_isArray(this.props.elementHeight)) {
-      if (React.Children.count(this.props.children) !== this.props.elementHeight.length) {
+    if (_isArray(this.computedProps.elementHeight)) {
+      if (React.Children.count(this.computedProps.children) !== this.computedProps.elementHeight.length) {
         throw new Error('There must be as many values provided in the elementHeight prop as there are children.');
       }
     }
   },
 
-  getScrollTop() {
-    return this.refs.scrollable.getDOMNode().scrollTop;
+  componentDidMount() {
+    this.utils.subscribeToScrollListener();
   },
 
   // Given the scrollTop of the container, computes the state the
@@ -154,22 +188,22 @@ var Infinite = React.createClass({
     var blockNumber = this.state.preloadBatchSize === 0 ? 0 : Math.floor(scrollTop / this.state.preloadBatchSize),
         blockStart = this.state.preloadBatchSize * blockNumber,
         blockEnd = blockStart + this.state.preloadBatchSize,
-        windowTop = Math.max(0, blockStart - this.state.preloadAdditionalHeight),
-        windowBottom = Math.min(this.state.infiniteComputer.getTotalScrollableHeight(),
+        apertureTop = Math.max(0, blockStart - this.state.preloadAdditionalHeight),
+        apertureBottom = Math.min(this.state.infiniteComputer.getTotalScrollableHeight(),
                         blockEnd + this.state.preloadAdditionalHeight);
+
     this.setState({
-      displayIndexStart: this.state.infiniteComputer.getDisplayIndexStart(windowTop),
-      displayIndexEnd: this.state.infiniteComputer.getDisplayIndexEnd(windowBottom)
+      displayIndexStart: this.state.infiniteComputer.getDisplayIndexStart(apertureTop),
+      displayIndexEnd: this.state.infiniteComputer.getDisplayIndexEnd(apertureBottom)
     });
   },
 
   infiniteHandleScroll(e) {
-    if (e.target !== this.refs.scrollable.getDOMNode()) {
+    if (this.utils.scrollShouldBeIgnored(e)) {
       return;
     }
-
-    this.props.handleScroll(this.refs.scrollable.getDOMNode());
-    this.handleScroll(e.target.scrollTop);
+    this.computedProps.handleScroll(React.findDOMNode(this.refs.scrollable));
+    this.handleScroll(this.utils.getScrollTop());
   },
 
   manageScrollTimeouts() {
@@ -186,7 +220,7 @@ var Infinite = React.createClass({
             isScrolling: false,
             scrollTimeout: undefined
           });
-        }, this.props.timeScrollStateLastsForAfterUserScrolls);
+        }, this.computedProps.timeScrollStateLastsForAfterUserScrolls);
 
     this.setState({
       isScrolling: true,
@@ -197,22 +231,23 @@ var Infinite = React.createClass({
   handleScroll(scrollTop) {
     this.manageScrollTimeouts();
     this.setStateFromScrollTop(scrollTop);
+
     var infiniteScrollBottomLimit = scrollTop >
         (this.state.infiniteComputer.getTotalScrollableHeight() -
-          this.props.containerHeight -
-          this.props.infiniteLoadBeginBottomOffset);
+          this.computedProps.containerHeight -
+          this.computedProps.infiniteLoadBeginBottomOffset);
     if (infiniteScrollBottomLimit && !this.state.isInfiniteLoading) {
       this.setState({
         isInfiniteLoading: true
       });
-      this.props.onInfiniteLoad();
+      this.computedProps.onInfiniteLoad();
     }
   },
 
   // Helpers for React styles.
   buildScrollableStyle() {
     return {
-      height: this.props.containerHeight,
+      height: this.computedProps.containerHeight,
       overflowX: 'hidden',
       overflowY: 'scroll'
     };
@@ -226,8 +261,8 @@ var Infinite = React.createClass({
   },
 
   render() {
-    var displayables = this.props.children.slice(this.state.displayIndexStart,
-                                                 this.state.displayIndexEnd + 1);
+    var displayables = this.computedProps.children.slice(this.state.displayIndexStart,
+                                                         this.state.displayIndexEnd + 1);
 
     var infiniteScrollStyles = {};
     if (this.state.isScrolling) {
@@ -239,10 +274,10 @@ var Infinite = React.createClass({
 
     // topSpacer and bottomSpacer take up the amount of space that the
     // rendered elements would have taken up otherwise
-    return <div className={this.props.className ? this.props.className : ''}
+    return <div className={this.computedProps.className}
                 ref="scrollable"
-                style={this.buildScrollableStyle()}
-                onScroll={this.infiniteHandleScroll}>
+                style={this.utils.buildScrollableStyle()}
+                onScroll={this.utils.nodeScrollListener}>
       <div ref="smoothScrollingWrapper" style={infiniteScrollStyles}>
         <div ref="topSpacer"
              style={this.buildHeightStyle(topSpacerHeight)}/>
@@ -250,7 +285,7 @@ var Infinite = React.createClass({
         <div ref="bottomSpacer"
              style={this.buildHeightStyle(bottomSpacerHeight)}/>
         <div ref="loadingSpinner">
-             {this.state.isInfiniteLoading ? this.props.loadingSpinnerDelegate : null}
+             {this.state.isInfiniteLoading ? this.computedProps.loadingSpinnerDelegate : null}
         </div>
       </div>
     </div>;

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -104,9 +104,9 @@ var Infinite = React.createClass({
     var computedProps = _assign({}, props);
     computedProps.containerHeight = props.useWindowAsScrollContainer ?
       window.innerHeight : props.containerHeight;
-    computedProps.preloadBatchSize = props.preloadBatchSize === 'number' ?
+    computedProps.preloadBatchSize = typeof props.preloadBatchSize === 'number' ?
       props.preloadBatchSize : computedProps.containerHeight / 2;
-    computedProps.preloadAdditionalHeight = props.preloadAdditionalHeight === 'number' ?
+    computedProps.preloadAdditionalHeight = typeof props.preloadAdditionalHeight === 'number' ?
       props.preloadAdditionalHeight : computedProps.containerHeight;
     return computedProps;
   },

--- a/src/utils/binary_index_search.js
+++ b/src/utils/binary_index_search.js
@@ -7,7 +7,7 @@ var opts = {
 
 var binaryIndexSearch = function(array/* : Array<number> */,
                                  item/* : number */,
-                                 opt/* : number */)/* : ?number */{
+                                 opt/* : number */)/* : ?number */ {
   var index;
 
   var high = array.length - 1,


### PR DESCRIPTION
This release introduces the ability to use the `window` as the scrolling div instead of 

React 0.13 is now the minimum version required to prepare for the coming deprecation of `getDOMNode`. Closes https://github.com/seatgeek/react-infinite/issues/79