### PR TITLE
Defensive programming.  Guard against missing ref

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -98,7 +98,10 @@ var Infinite = React.createClass({
       utilities.unsubscribeFromScrollListener = () => {};
       utilities.nodeScrollListener = this.infiniteHandleScroll;
       utilities.getScrollTop = () => {
-        var scrollable = React.findDOMNode(this.refs.scrollable);
+        var scrollable;
+        if (this.refs.scrollable) {
+          scrollable = React.findDOMNode(this.refs.scrollable);
+        }
         return scrollable ? scrollable.scrollTop : 0;
       };
       utilities.scrollShouldBeIgnored = event => event.target !== React.findDOMNode(this.refs.scrollable);


### PR DESCRIPTION
This was causing an error in my react application:

```
TypeError: Cannot read property 'context' of null
    at ReactCompositeComponentMixin.updateComponent (ReactCompositeComponent.js:597)
    at wrapper [as updateComponent] (ReactPerf.js:70)
    at ReactCompositeComponentMixin.receiveComponent (ReactCompositeComponent.js:506)
    at Object.ReactReconciler.receiveComponent (ReactReconciler.js:97)
    at Object.ReactChildReconciler.updateChildren (ReactChildReconciler.js:83)
    at ReactDOMComponent.ReactMultiChild.Mixin._updateChildren (ReactMultiChild.js:277)
    at ReactDOMComponent.ReactMultiChild.Mixin.updateChildren (ReactMultiChild.js:251)
    at ReactDOMComponent.Mixin._updateDOMChildren (ReactDOMComponent.js:470)
    at ReactDOMComponent.Mixin.updateComponent (ReactDOMComponent.js:319)
    at ReactDOMComponent.Mixin.receiveComponent (ReactDOMComponent.js:303)
    at Object.ReactReconciler.receiveComponent (ReactReconciler.js:97)
```

Guarding against this fixed this issue.