### PR TITLE
Allow other overflowY values on root div

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -50,7 +50,9 @@ var Infinite = React.createClass({
     isInfiniteLoading: React.PropTypes.bool,
     timeScrollStateLastsForAfterUserScrolls: React.PropTypes.number,
 
-    className: React.PropTypes.string
+    className: React.PropTypes.string,
+
+    overflowY: React.PropTypes.onOf(['visible', 'hidden', 'scroll', 'auto', 'initial', 'inherit'])
   },
   statics: {
     containerHeightScaleFactor(factor) {
@@ -87,7 +89,9 @@ var Infinite = React.createClass({
       isInfiniteLoading: false,
       timeScrollStateLastsForAfterUserScrolls: 150,
 
-      className: ''
+      className: '',
+
+      overflowY: 'scroll'
     };
   },
 
@@ -215,7 +219,7 @@ var Infinite = React.createClass({
         return {
           height: this.computedProps.containerHeight,
           overflowX: 'hidden',
-          overflowY: 'scroll',
+          overflowY: this.computedProps.overflowY,
           WebkitOverflowScrolling: 'touch'
         };
       };

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -91,7 +91,7 @@ var Infinite = React.createClass({
 
       className: '',
 
-      overflowY: {}
+      style: {}
     };
   },
 

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -52,7 +52,7 @@ var Infinite = React.createClass({
 
     className: React.PropTypes.string,
 
-    overflowY: React.PropTypes.onOf(['visible', 'hidden', 'scroll', 'auto', 'initial', 'inherit'])
+    style: React.PropTypes.object
   },
   statics: {
     containerHeightScaleFactor(factor) {
@@ -91,7 +91,7 @@ var Infinite = React.createClass({
 
       className: '',
 
-      overflowY: 'scroll'
+      overflowY: {}
     };
   },
 
@@ -216,12 +216,12 @@ var Infinite = React.createClass({
       utilities.scrollShouldBeIgnored = event => event.target !== ReactDOM.findDOMNode(this.refs.scrollable);
 
       utilities.buildScrollableStyle = () => {
-        return {
+        return Object.assign({}, {
           height: this.computedProps.containerHeight,
           overflowX: 'hidden',
-          overflowY: this.computedProps.overflowY,
+          overflowY: 'scroll',
           WebkitOverflowScrolling: 'touch'
-        };
+        }, this.computedProps.style);
       };
     }
     return utilities;

--- a/typelib/component/react_infinite_types.js
+++ b/typelib/component/react_infinite_types.js
@@ -32,7 +32,7 @@ type ReactInfiniteProvidedDefaultProps = {
 
   className: string,
 
-  overflowY: string
+  style: object
 }
 
 type ReactInfiniteProps = {
@@ -57,7 +57,7 @@ type ReactInfiniteProps = {
 
   className?: string,
 
-  overflowY?: string
+  style?: object
 };
 
 type ReactInfiniteComputedProps = {

--- a/typelib/component/react_infinite_types.js
+++ b/typelib/component/react_infinite_types.js
@@ -30,7 +30,9 @@ type ReactInfiniteProvidedDefaultProps = {
   isInfiniteLoading: boolean,
   timeScrollStateLastsForAfterUserScrolls: number,
 
-  className: string
+  className: string,
+
+  overflowY: string
 }
 
 type ReactInfiniteProps = {
@@ -53,7 +55,9 @@ type ReactInfiniteProps = {
   isInfiniteLoading?: boolean,
   timeScrollStateLastsForAfterUserScrolls?: number,
 
-  className?: string
+  className?: string,
+
+  overflowY?: string
 };
 
 type ReactInfiniteComputedProps = {


### PR DESCRIPTION
I'd be great if I could change the overflowY property on the root div without using a classname + css. This  adds a new prop, overflowY, which defaults to scroll.