### PR TITLE
Fix switch to infinite loading in displayBottomUpwards mode

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -281,7 +281,7 @@ var Infinite = React.createClass({
       var lowestScrollTop = this.getLowestPossibleScrollTop();
       if (this.shouldAttachToBottom && this.utils.getScrollTop() < lowestScrollTop) {
         this.utils.setScrollTop(lowestScrollTop);
-      } else if (prevProps.isInfiniteLoading && !this.props.isInfiniteLoading) {
+      } else {
         this.utils.setScrollTop(this.state.infiniteComputer.getTotalScrollableHeight() -
           prevState.infiniteComputer.getTotalScrollableHeight() +
           this.preservedScrollState);


### PR DESCRIPTION
- old condition was blocking at the 2nd pass e.g at second getScrollTop() > lowestScrollTop
- this fix works for our use case
- but not sure if this fix breaks other features from react-infinite lib