### PR TITLE
Permit containerHeight values of 0

### DIFF
--- a/src/utils/checkProps.js
+++ b/src/utils/checkProps.js
@@ -7,7 +7,7 @@ var _isFinite = require('lodash.isfinite');
 
 module.exports = function(props) {
   var rie = 'Invariant Violation: ';
-  if (!(props.containerHeight || props.useWindowAsScrollContainer)) {
+  if (!(typeof props.containerHeight === 'number' || props.useWindowAsScrollContainer)) {
     throw new Error(rie + 'Either containerHeight or useWindowAsScrollContainer must be provided.');
   }
 


### PR DESCRIPTION
In cases where the containerHeight is initialized to 0 or changes to 0
dynamically, we should not throw an exception.