### PR TITLE
Loading items on container height dynamically changed

### DIFF
--- a/__tests__/infinite_test.js
+++ b/__tests__/infinite_test.js
@@ -448,6 +448,37 @@ describe("React Infinite's Infinite Scroll Capabilities", function() {
     expect(infiniteSpy).not.toHaveBeenCalled();
   });
 
+  it('triggers the onInfiniteLoad function when containerHeight changes', function() {
+    var infiniteSpy = jasmine.createSpy('infiniteSpy');
+    var elementHeight = 200;
+
+    var rootNode = document.createElement('div');
+
+    ReactDOM.render(
+      <Infinite elementHeight={elementHeight}
+                containerHeight={400}
+                onInfiniteLoad={infiniteSpy}
+                infiniteLoadBeginEdgeOffset={100}
+                className={"correct-class-name"}>
+        {renderHelpers.divGenerator(2, elementHeight)}
+      </Infinite>,
+      rootNode
+    );
+
+    ReactDOM.render(
+      <Infinite elementHeight={elementHeight}
+              containerHeight={1000}
+              onInfiniteLoad={infiniteSpy}
+              infiniteLoadBeginEdgeOffset={100}
+              className={"correct-class-name"}>
+              {renderHelpers.divGenerator(2, elementHeight)}
+      </Infinite>,
+      rootNode
+    );
+
+    expect(infiniteSpy).toHaveBeenCalled();
+  });
+
   it('triggers the onInfiniteLoad function when scrolling past infiniteLoadBeginEdgeOffset', function() {
     var infiniteSpy = jasmine.createSpy('infiniteSpy');
     var elementHeight = 200;

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -305,6 +305,15 @@ var Infinite = React.createClass({
     if (isMissingVisibleRows) {
       this.onInfiniteLoad();
     }
+
+    if (this.props.containerHeight !== prevProps.containerHeight) {
+      const scrollTop = this.utils.getScrollTop();
+      const newApertureState = infiniteHelpers.recomputeApertureStateFromOptionsAndScrollTop(this.state, scrollTop);
+      if (this.passedEdgeForInfiniteScroll(scrollTop) && !this.state.isInfiniteLoading) {
+        this.setState({...newApertureState});
+        this.onInfiniteLoad();
+      }
+    }
   },
 
   componentDidMount() {


### PR DESCRIPTION
In my case, the container size is not fixed and is changed according to page size (flexible markup).

The problem appears when the page is resized without scroll events on `react-infinite` component, it leads to empty space below previously loaded requests. The PR fixes it.