### PR TITLE
Creating a 'onChangeScrollState' callback function prop…

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -303,6 +303,12 @@ var Infinite = createReactClass({
       this.setState(newApertureState);
     }
 
+    if (typeof this.props.onChangeScrollState === 'function'){
+      if (this.state.isScrolling !== prevState.isScrolling){
+        return this.props.onChangeScrollState(this.state.isScrolling);
+      }
+    }
+
     const isMissingVisibleRows = hasLoadedMoreChildren && !this.hasAllVisibleItems() && !this.state.isInfiniteLoading;
     if (isMissingVisibleRows) {
       this.onInfiniteLoad();
@@ -326,14 +332,6 @@ var Infinite = createReactClass({
 
   componentWillUnmount() {
     this.utils.unsubscribeFromScrollListener();
-  },
-
-  componentDidUpdate(pastState){
-    if (typeof this.props.onChangeScrollState === 'function'){
-      if (this.state.isScrolling !== pastState.isScrolling){
-        return this.props.onChangeScrollState(this.state.isScrolling);
-      }
-    }
   },
 
   infiniteHandleScroll(e: SyntheticEvent) {

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -448,15 +448,6 @@ var Infinite = createReactClass({
         {this.state.isInfiniteLoading ? this.computedProps.loadingSpinnerDelegate : null}
       </div>;
 
-    function wrap(children : Element){
-      if (this.props.smoothScrollingWrapper){
-        return React.cloneElement(this.props.smoothScrollingWrapper, {}, children);
-      }
-      return (
-          null
-      );
-    }
-
     // topSpacer and bottomSpacer take up the amount of space that the
     // rendered elements would have taken up otherwise
     return (


### PR DESCRIPTION
…to be called (if exists) in componentDidUpdate when pastState.isScrolling !== this.state.isScrolling. Maybe it should go into componentWillUpdate?

This function prop allows me to set "pointer-events: none" on a parent element while scrolling. In my case, list items (`displayables`) are within a horizontally scrollable container which causes Chrome to lag/skip slightly during scrolling. Setting `pointer-events: none` on the element with `overflow-x: auto`, during vertical scrolling, fixes this.

Another edit included in this PR is changing a couple of defaultProps for function props/properties from `function(){}` to either null or undefined, so function doesn't get bound to an element at all if not provided/used. Point was to slightly improve performance, if possible.


In near future, would like to convert to ES6 module syntax (`class Infinite extends React.Component { ...`) if no one else has started on this.
