### PR TITLE
add props method to get this.scrollable

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -315,6 +315,10 @@ class Infinite extends React.Component<
         this.utils.setScrollTop(lowestScrollTop);
       }
     }
+
+    if (this.props.getScrollable) {
+      this.props.getScrollable(this.scrollable)
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
I want to get the inner dom node (this.scrollable). Please let me know if there's other way around. Thanks!