### PR TITLE
allow for other elements to be above a windowed infinite list

### DIFF
--- a/__tests__/infinite_test.js
+++ b/__tests__/infinite_test.js
@@ -680,6 +680,14 @@ describe('React Infinite when the window is used as the Container', function() {
 
     return listenerTriggered.then(listener => {
       window.pageYOffset = 1500;
+      rootNode.node.scrollable.getBoundingClientRect = () => ({
+        width: 1440,
+        height: 4000,
+        top: -1500,
+        left: 0,
+        right: 1440,
+        bottom: 2500,
+      });
       listener();
       expect(mountToJson(rootNode)).toMatchSnapshot();
       window.addEventListener = oldAdd;

--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -154,7 +154,13 @@ class Infinite extends React.Component<
         window.removeEventListener('scroll', this.infiniteHandleScroll);
       };
       utilities.nodeScrollListener = () => {};
-      utilities.getScrollTop = () => window.pageYOffset;
+      utilities.getScrollTop = () => {
+        if (this.computedProps && this.computedProps.displayBottomUpwards) {
+          return window.pageYOffset;
+        }
+
+        return this.scrollable ? Math.max(0, -this.scrollable.getBoundingClientRect().top) : 0;
+      }
       utilities.setScrollTop = top => {
         window.scroll(window.pageXOffset, top);
       };


### PR DESCRIPTION
Using the scrollable div's boundingClientRect for top-down scrolling in the window allows us to have big fancy page headers above the beginning of our lists.