### PR TITLE
Scroll bar issue is fixed

### DIFF
--- a/src/react-infinite.jsx
+++ b/src/react-infinite.jsx
@@ -182,7 +182,7 @@ class Infinite extends React.Component<
           {
             height: this.computedProps.containerHeight,
             overflowX: 'hidden',
-            overflowY: 'scroll',
+            overflowY: 'auto',
             WebkitOverflowScrolling: 'touch'
           },
           this.computedProps.styles.scrollableStyle || {}


### PR DESCRIPTION
In this update, the unnecessary scrollbar is removed using the auto tag in scroll bar for overflowing y-axis. In current situation if the container height is 600px and the element inside it only using the area under 600 px, the scrollbar is still visible. By this update, the scrollbar will only show when it required for loading elements hight more then the container size.